### PR TITLE
refactor to simply code using Mime struct and mime_guess crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,5 @@ serde = "1.0.136"
 rust-embed = {version = "6.4.2", features = ["include-exclude"]}
 serde_yaml = "0.9.14"
 epub-builder = { git = "https://github.com/ultrasaurus/epub-builder", branch="ultra-main" }
+mime_guess = "2.0.4"
+mime = "0.3.17"

--- a/README.md
+++ b/README.md
@@ -56,14 +56,6 @@ until there are multiple maintainers or additional users.
   there's a bit more clarity on options needed. Or if someone wants it,
   they can propose a format with config options, file an issue and link it here.
 
-### TODO - if requested
-- file extensons: particular file extensions are hard-coded; however,
-  there are common variants not currently supported
-  - code writes HTML files with `.html` extension. Alternate `.htm` could
-    be future config option
-  - code identifies markdown files with `.md` extension. Would be easy to
-    also look for `.markdown`
-
 ### TODO - tech debt
 - need to write some more automated tests
 - stylesheet.css is auto-generated for TOC, consider moving book contents

--- a/src/document.rs
+++ b/src/document.rs
@@ -284,13 +284,24 @@ mod tests {
         assert_eq!(output_str, HELLO_HTML);
     }
 
+    struct TestData<'a> {
+        md: &'a str,
+        html: &'a str,
+    }
+
+    fn verify_write_html_with_test_data(test_data: Vec<TestData>) {
+        test_data.iter().for_each(|test| {
+            let markdown: String = test.md.to_string();
+            let mut output = Vec::new();
+            Document::write_html(&mut output, &markdown).unwrap();
+            let output_str = std::str::from_utf8(&output).unwrap();
+            assert_eq!(output_str, test.html);
+        });
+    }
+
     #[test]
     // test of standard CommonMark formatting
     fn test_write_html_cmark_basics() {
-        struct TestData<'a> {
-            md: &'a str,
-            html: &'a str,
-        }
         let test_data = vec![
             TestData {
                 // basic text
@@ -313,12 +324,17 @@ mod tests {
                 html: "<p>link: <a href=\"https://example.com/thing\">&quot;thing</a></p>\n",
             },
         ];
-        test_data.iter().for_each(|test| {
-            let markdown: String = test.md.to_string();
-            let mut output = Vec::new();
-            Document::write_html(&mut output, &markdown).unwrap();
-            let output_str = std::str::from_utf8(&output).unwrap();
-            assert_eq!(output_str, test.html);
-        });
+        verify_write_html_with_test_data(test_data);
+    }
+
+    #[test]
+    // test of converting markdwon links to .html
+    fn test_write_html_link_to_markdown() {
+        let test_data = vec![TestData {
+            // .md link conversion to .html
+            md: "link: [thing](https://example.com/thing.md)",
+            html: "<p>link: <a href=\"https://example.com/thing.html\">thing</a></p>\n",
+        }];
+        verify_write_html_with_test_data(test_data);
     }
 }

--- a/src/document.rs
+++ b/src/document.rs
@@ -237,7 +237,6 @@ impl Document {
                                     } else {
                                         "".into()
                                     };
-                                    // TODO: do we need to escape any text?  or is it already done elsewhere?
                                     let link_tag= format!("<a href=\"{}\" title=\"{}\" class=\"audio\"><span class=\"fa-solid fa-play\">{}</span></a>",
                                         &url, &title, &link_text);
                                     let audio_tag= format!("<audio controls><source src=\"{}\" type=\"{}\">Your browser does not support the audio element. {}</audio>",
@@ -294,16 +293,24 @@ mod tests {
         }
         let test_data = vec![
             TestData {
+                // basic text
                 md: "hello",
                 html: "<p>hello</p>\n",
             },
             TestData {
+                // unordered list
                 md: "* one\n* two",
                 html: "<ul>\n<li>one</li>\n<li>two</li>\n</ul>\n",
             },
             TestData {
+                // simple link
                 md: "link: [thing](https://example.com/thing)",
                 html: "<p>link: <a href=\"https://example.com/thing\">thing</a></p>\n",
+            },
+            TestData {
+                // link with mis-matched quote in title
+                md: r#"link: ["thing](https://example.com/thing)"#,
+                html: "<p>link: <a href=\"https://example.com/thing\">&quot;thing</a></p>\n",
             },
         ];
         test_data.iter().for_each(|test| {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,44 +1,5 @@
 mod dir_entry;
 pub use self::dir_entry::DirEntryExt;
-mod path;
-pub use self::path::get_mimetype;
+
+pub mod path;
 pub use self::path::PathExt;
-
-use pulldown_cmark::CowStr;
-use std::{borrow::Cow, path::Path};
-
-// return the extension of an url as a lowercase string
-// or empty string, if there is no extension
-pub fn get_ext<T: AsRef<str>>(url: T) -> Cow<'static, str> {
-    let path = Path::new(url.as_ref());
-    path.get_ext().unwrap_or(Cow::Borrowed(""))
-}
-
-pub fn is_audio_file(url: &CowStr) -> bool {
-    let audio_format = ["mp3", "mp4", "m4a", "wav", "ogg"];
-    let path = Path::new(url.as_ref());
-    if let Some(ext_osstr) = path.extension() {
-        let extension = ext_osstr.to_string_lossy().to_lowercase();
-        if audio_format.contains(&extension.as_str()) {
-            return true;
-        }
-    }
-    false
-}
-
-#[cfg(test)]
-mod tests {
-    // importing names from outer (for mod tests) scope.
-    use super::*;
-
-    #[test]
-    fn test_get_ext_png() {
-        let result = get_ext("foo.png");
-        assert_eq!(result, "png".to_string());
-    }
-    #[test]
-    fn test_get_ext_empty() {
-        let result = get_ext("");
-        assert_eq!(result, "".to_string());
-    }
-}

--- a/src/util/path.rs
+++ b/src/util/path.rs
@@ -9,6 +9,7 @@ pub trait PathExt {
     // and create any that don't exist
     fn create_all_parent_dir(&self) -> std::io::Result<()>;
     fn get_ext(&self) -> Option<Cow<'static, str>>;
+    fn get_ext_str(&self) -> Option<&str>;
     fn mimetype(&self) -> Option<Mime>;
     fn is_markdown(&self) -> bool;
 }
@@ -22,6 +23,13 @@ impl PathExt for Path {
         Ok(())
     }
 
+    fn get_ext_str(&self) -> Option<&str> {
+        if let Some(ext_osstr) = self.extension() {
+            ext_osstr.to_str()
+        } else {
+            None
+        }
+    }
     fn get_ext(&self) -> Option<Cow<'static, str>> {
         if let Some(ext_osstr) = self.extension() {
             Some(Cow::Owned(ext_osstr.to_string_lossy().to_lowercase()))

--- a/src/util/path.rs
+++ b/src/util/path.rs
@@ -1,44 +1,15 @@
-//-- Path utlity functions
-use std::{borrow::Cow, path::Path};
+//-- Path utlity functions -----------------------------------------------
+// extensons to Path struct and related helper functions
 
-// return mimetype given an extension
-pub fn get_mimetype(ext: &str) -> Cow<'static, str> {
-    info!("get_mimetype for: {}", ext);
-    Cow::from(match ext {
-        "mp3" => "audio/mpeg",
-        "mp4" => "video/mp4",
-        "m4a" => "audio/mp4",
-        "wav" => "audio/wav",
-        "ogg" => "audio/ogg",
-        "jpg" => "image/jpeg",
-        "jpeg" => "image/jpeg",
-        "png" => "image/png",
-        "gif" => "image/gif",
-        "svg" => "image/svg+xml",
-        "webp" => "image/webp",
-        "pdf" => "application/pdf",
-        "zip" => "application/zip",
-        "gz" => "application/gzip",
-        "tar" => "application/x-tar",
-        "txt" => "text/plain",
-        "md" => "text/markdown",
-        "html" => "text/html",
-        "css" => "text/css",
-        "js" => "text/javascript",
-        "json" => "application/json",
-        "xml" => "application/xml",
-        "yaml" => "text/yaml",
-        "yml" => "text/yaml",
-        _ => "application/octet-stream",
-    })
-}
+use mime::Mime;
+use std::{borrow::Cow, path::Path};
 
 pub trait PathExt {
     // given a path, ensure that all parent directories of that path exist
     // and create any that don't exist
     fn create_all_parent_dir(&self) -> std::io::Result<()>;
     fn get_ext(&self) -> Option<Cow<'static, str>>;
-    fn mimetype(&self) -> Cow<'static, str>;
+    fn mimetype(&self) -> Option<Mime>;
     fn is_markdown(&self) -> bool;
 }
 
@@ -58,9 +29,8 @@ impl PathExt for Path {
             None
         }
     }
-    fn mimetype(&self) -> Cow<'static, str> {
-        let ext = self.get_ext().unwrap_or(Cow::Borrowed(""));
-        get_mimetype(&ext)
+    fn mimetype(&self) -> Option<Mime> {
+        mime_guess::from_path(self).first()
     }
     fn is_markdown(&self) -> bool {
         if let Some(ext) = self.extension() {
@@ -88,13 +58,13 @@ mod tests {
         assert_eq!(result, None);
     }
     #[test]
-    fn test_get_mimetype_png() {
-        let result = get_mimetype("png");
-        assert_eq!(result, "image/png".to_string());
+    fn test_imetype_png() {
+        let result = Path::new("foo.png").mimetype();
+        assert_eq!(result, Some(mime::IMAGE_PNG));
     }
     #[test]
     fn test_get_mimetype_empty() {
-        let result = get_mimetype("");
-        assert_eq!(result, "application/octet-stream".to_string());
+        let result = Path::new("foo").mimetype();
+        assert_eq!(result, None);
     }
 }

--- a/src/web.rs
+++ b/src/web.rs
@@ -180,10 +180,13 @@ impl Web<'_> {
                     .strip_prefix(&self.template_dir_path)
                     .expect("strip prefix match");
 
-                let mimetype = rel_path.mimetype();
+                let mimetype = rel_path.mimetype().unwrap_or(mime::TEXT_PLAIN_UTF_8);
                 info!("  rel_path: {}, mimetype: {}", rel_path.display(), mimetype);
-                let result =
-                    epub.add_resource(rel_path, fs::File::open(dir_entry.path())?, mimetype);
+                let result = epub.add_resource(
+                    rel_path,
+                    fs::File::open(dir_entry.path())?,
+                    mimetype.to_string(),
+                );
                 // TODO: figure out why "?" doesn't work at end of statement above
                 if result.is_err() {
                     anyhow::bail!(


### PR DESCRIPTION
refactor utils to use mime and mime_guess crates
refactor Document fn write_html to use mime_guess (plus a few tests!)

- PathExt use mime_guess to return mime type from a path
- Document::write_html
  - use mime_guess directly since CowStr url not a Path
  - match on structured mime type
- delete unused utility functions

TODO:
- [x] manually core functionality with examples 
  - [x] nested-files
  - [x] book-html
  - [x] book-md
