### PR TITLE
generate gh-pages index with links to some examples

### DIFF
--- a/.github/workflows/action-deploy.yml
+++ b/.github/workflows/action-deploy.yml
@@ -2,7 +2,7 @@ name: Deploy Artifacts to GitHub Pages
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "deploy" ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -42,13 +42,21 @@ jobs:
 
       - name: Build examples
         run: |
-         cd examples/nested-files
-         webgenr
-         cd ../book-md
-         webgenr
-         cd ../book-html
-         webgenr
-         cd ../../
+          export BRANCH_NAME=${{ github.ref_name }}
+          source gh-pages/build.sh
+          pwd
+          ls -R1 gh-pages
+
+          OUT_DIR="gh-pages/_website"
+
+          ./examples/nested-files/build.sh
+          mv _website $OUT_DIR/nested-files
+
+          ./examples/book-html/build.sh
+          mv book.epub $OUT_DIR/book-html.epub
+
+          ./examples/book-md/build.sh
+          mv book.epub $OUT_DIR/book-md.epub
 
       - name: Setup Pages
         uses: actions/configure-pages@v3
@@ -62,7 +70,7 @@ jobs:
         uses: actions/upload-pages-artifact@v1
         with:
           # A file, directory or wildcard pattern that describes what to upload
-          path: ./examples/nested-files/_website
+          path: ./gh-pages/_website
 
       - name: Deploy!
         id: deployment

--- a/gh-pages/build.sh
+++ b/gh-pages/build.sh
@@ -1,0 +1,24 @@
+
+#! /bin/sh
+
+cd gh-pages
+
+INDEX_FILE="source/index.md"
+echo $INDEX_FILE
+
+DATE_STRING=$(date +"%a, %b %d %Y - %I:%M %p")
+echo $DATE_STRING
+
+cat <<EOT >> $INDEX_FILE
+\`\`\`
+$DATE_STRING
+branch=$BRANCH_NAME
+$GITHUB_SHA
+\`\`\`
+EOT
+
+
+webgenr -i source
+cd ..
+
+

--- a/gh-pages/source/index.md
+++ b/gh-pages/source/index.md
@@ -1,0 +1,7 @@
+# Demos
+
+* Website example: [nested-files](nested-files)
+* Book example (EPUB): [book-md.epub](book-md.epub)
+
+
+


### PR DESCRIPTION
build all examples on deploy
use webgenr to generate demo index.html from markdown include build info on index page
run deploy action on two branches: main, and for testing a specific other branch "deploy"